### PR TITLE
Clarify the README with regards to including Gon in classic applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,16 @@ For rails use [gon](https://github.com/gazay/gon).
 
 `my_sinatra_application.rb`
 
-``` ruby
-register Gon::Sinatra
-# and if you want to the use Rabl integration
-register Gon::Sinatra::Rabl
+**Note: For classic (non-modular) applications, you still have to explicitely register `Gon::Sinatra`**
 
-#or, in a classy app:
+``` ruby
+# For classic applications:
+
+Sinatra::register Gon::Sinatra
+# and if you want to the use Rabl integration
+Sinatra::register Gon::Sinatra::Rabl
+
+# For modular applications:
 
 class MySinatraApplication < Sinatra::Base #or Padrino::Application
   register Gon::Sinatra


### PR DESCRIPTION
In sinatra applications, the standard practice is to put your extension's namespace instead the Sinatra namespace -- eg `Sinatra::Gon`. This allows you to auto-include the extension for classic (non-modular) applications.

Classic application writers (especially newbies) have come to expect this, and confusion results when an extension doesn't follow this pattern (as I just found out on #sinatra).

In addition, the readme doesn't state clearly that extra action is required for classic application users, and the code given to these users is wrong.
