### PR TITLE
Use a Tilt::Cache to cache rabl files sources

### DIFF
--- a/lib/gon/sinatra/rabl.rb
+++ b/lib/gon/sinatra/rabl.rb
@@ -1,11 +1,19 @@
 require 'rabl'
+require 'tilt'
 
 module Gon
   module Sinatra
     module Rabl
       class << self
+        def cache
+          @cache ||= Tilt::Cache.new
+        end
+
         def parse_rabl(rabl_path, controller)
-          source = File.read(rabl_path)
+          source = cache.fetch(rabl_path) do
+            File.read(rabl_path)
+          end
+
           rabl_engine = ::Rabl::Engine.new(source, :format => 'json')
           output = rabl_engine.render(controller, {})
           ::Rabl.configuration.json_engine.decode(output)

--- a/spec/gon/gon_spec.rb
+++ b/spec/gon/gon_spec.rb
@@ -69,6 +69,18 @@ describe Gon::Sinatra, '#all_variables' do
     @gon.objects.length.should == 2
   end
 
+  it 'caches the rabl template' do
+    @gon.clear
+    @objects = [1,2]
+    @gon.rabl 'spec/test_data/sample.rabl', :instance => self
+
+    File.should_not_receive(:read)
+    @gon.clear
+    @objects = [1,2,3]
+    @gon.rabl 'spec/test_data/sample.rabl', :instance => self
+    @gon.objects.length.should == 3
+  end
+
   def request
     @request ||= double 'request', :env => {}
   end


### PR DESCRIPTION
It's preferred to not hit the filesystem everytime you need a
template.  I used tilt cache since sinatra depends on tilt.  I
didn't mess with the gemspec in this case.
