### PR TITLE
Specifies error raised when setting public method as variable in specs

### DIFF
--- a/spec/gon/gon_spec.rb
+++ b/spec/gon/gon_spec.rb
@@ -49,7 +49,7 @@ describe Gon::Sinatra, '#all_variables' do
 
   it 'returns exception if try to set public method as variable' do
     @gon.clear
-    expect { @gon.all_variables = 123 }.to raise_error
+    expect { @gon.all_variables = 123 }.to raise_error(RuntimeError)
   end
 
   it 'should be threadsafe' do


### PR DESCRIPTION
Hello,
Rspec raised this warning when I ran the specs:

`WARNING: Using the raise_error matcher without providing a specific error or message risks false positives, since raise_error will match when Ruby raises a NoMethodError, NameError or ArgumentError, potentially allowing the expectation to pass without even executing the method you are intending to call. Instead consider providing a specific error class or message.`

So I added the specific error to be raised (RuntimeError) within the 'returns exception if try to set public method as variable' example.  

Cheers,
Trevor
